### PR TITLE
Session 7 NotificationCenter

### DIFF
--- a/ios-training-fujii/Base.lproj/Main.storyboard
+++ b/ios-training-fujii/Base.lproj/Main.storyboard
@@ -70,7 +70,7 @@
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Close"/>
                                         <connections>
-                                            <action selector="closeButton" destination="BYZ-38-t0r" eventType="touchUpInside" id="Me3-0f-hcG"/>
+                                            <action selector="closeView" destination="BYZ-38-t0r" eventType="touchUpInside" id="fBR-MG-189"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ggs-VG-CBM">
@@ -78,7 +78,7 @@
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="Reload"/>
                                         <connections>
-                                            <action selector="weatherReloadButton" destination="BYZ-38-t0r" eventType="touchUpInside" id="Qth-Zc-cDC"/>
+                                            <action selector="reloadWeather" destination="BYZ-38-t0r" eventType="touchUpInside" id="Xdj-nU-bMj"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/ios-training-fujii/MainViewController.swift
+++ b/ios-training-fujii/MainViewController.swift
@@ -19,8 +19,7 @@ final class MainViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        reloadWeather(area: "tokyo")
-        
+
         NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
             .sink { [weak self] notification in
                 self?.reloadWeather()

--- a/ios-training-fujii/MainViewController.swift
+++ b/ios-training-fujii/MainViewController.swift
@@ -19,8 +19,22 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         reloadWeather(area: "tokyo")
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(viewWillEnterForeground(_:)),
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+
     }
     
+
+    @objc func viewWillEnterForeground(_ notification: Notification?) {
+        if (self.isViewLoaded && (self.view.window != nil)) {
+            reloadWeather(area: "tokyo")
+        }
+    }
+
     @IBAction func reloadWeather() {
         reloadWeather(area: "tokyo")
     }

--- a/ios-training-fujii/MainViewController.swift
+++ b/ios-training-fujii/MainViewController.swift
@@ -10,11 +10,11 @@ import YumemiWeather
 
 final class MainViewController: UIViewController {
     
-    
     @IBOutlet @ViewLoading private var weatherImageView: UIImageView
     @IBOutlet @ViewLoading private var minTemperatureLabel: UILabel
     @IBOutlet @ViewLoading private var maxTemperatureLabel: UILabel
     
+    @ViewLoading private var alert: UIAlertController
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,13 +25,26 @@ final class MainViewController: UIViewController {
             name: UIApplication.willEnterForegroundNotification,
             object: nil
         )
-
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(viewDidEnterBackground(_:)),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        
     }
     
 
     @objc func viewWillEnterForeground(_ notification: Notification?) {
         if (self.isViewLoaded && (self.view.window != nil)) {
             reloadWeather(area: "tokyo")
+        }
+    }
+    
+    @objc func viewDidEnterBackground(_ notification: Notification?) {
+        if (self.isViewLoaded && (self.view.window != nil)) {
+            alert.dismiss(animated: true)
         }
     }
 
@@ -92,7 +105,7 @@ final class MainViewController: UIViewController {
     }
     
     private func showAlert(title: String, message: String) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "閉じる", style: .default))
         self.present(alert, animated: true)
     }

--- a/ios-training-fujii/MainViewController.swift
+++ b/ios-training-fujii/MainViewController.swift
@@ -15,7 +15,7 @@ final class MainViewController: UIViewController {
     @IBOutlet @ViewLoading private var minTemperatureLabel: UILabel
     @IBOutlet @ViewLoading private var maxTemperatureLabel: UILabel
     
-    var cancellables = Set<AnyCancellable>()
+    private var cancellables = Set<AnyCancellable>()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/ios-training-fujii/MainViewController.swift
+++ b/ios-training-fujii/MainViewController.swift
@@ -23,7 +23,7 @@ final class MainViewController: UIViewController {
         
         NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
             .sink { [weak self] notification in
-                self?.viewWillEnterForeground()
+                self?.reloadWeather()
             }
             .store(in: &cancellables)
         

--- a/ios-training-fujii/MainViewController.swift
+++ b/ios-training-fujii/MainViewController.swift
@@ -26,28 +26,6 @@ final class MainViewController: UIViewController {
                 self?.reloadWeather()
             }
             .store(in: &cancellables)
-        
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(viewDidEnterBackground(_:)),
-            name: UIApplication.didEnterBackgroundNotification,
-            object: nil
-        )
-    }
-    
-    func viewWillEnterForeground() {
-        reloadWeather()
-    }
-
-    @objc func viewDidEnterBackground(_ notification: Notification?) {
-        if (self.isViewLoaded && (self.view.window != nil)) {
-            // alert以外の画面に遷移する場合は修正が必要
-            presentedViewController?.dismiss(animated: true)
-        }
-    }
-    
-    func background() {
-        presentedViewController?.dismiss(animated: true)
     }
 
     @IBAction func reloadWeather() {

--- a/ios-training-fujii/MainViewController.swift
+++ b/ios-training-fujii/MainViewController.swift
@@ -14,8 +14,6 @@ final class MainViewController: UIViewController {
     @IBOutlet @ViewLoading private var minTemperatureLabel: UILabel
     @IBOutlet @ViewLoading private var maxTemperatureLabel: UILabel
     
-    @ViewLoading private var alert: UIAlertController
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         reloadWeather(area: "tokyo")
@@ -44,7 +42,8 @@ final class MainViewController: UIViewController {
     
     @objc func viewDidEnterBackground(_ notification: Notification?) {
         if (self.isViewLoaded && (self.view.window != nil)) {
-            alert.dismiss(animated: true)
+            // alert以外の画面に遷移する場合は修正が必要
+            presentedViewController?.dismiss(animated: true)
         }
     }
 
@@ -105,7 +104,7 @@ final class MainViewController: UIViewController {
     }
     
     private func showAlert(title: String, message: String) {
-        alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "閉じる", style: .default))
         self.present(alert, animated: true)
     }


### PR DESCRIPTION
# アプリがフォアグラウンドにきたとき天気予報を更新する

## 概要
Session 7の[NotificationCenter](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/NotificationCenter.md)に取り組み

## 備考
### 課題の「エラーが表示された状態での動きも確認してみましょう」について

- エラーが表示された状態でアプリをバックグラウンドからフォアグラウンドに戻した場合は、アラートが閉じられず天気の状態が更新されないことが確認された
- 対策としてアプリがバックグラウンドに入った時にアラートを閉じる処理を実装した

### 備考
アラートを閉じる処理についてご意見をお聞きしたいです。
- 先にalertを`private var alert: UIAlertController?`と定義し、`alert.dismiss(animated: true)`で閉じる
  - アラートを閉じる
  <img width="664" alt="スクリーンショット 2023-12-15 14 25 11" src="https://github.com/yumemi-inc/ios-training-fujii/assets/130953322/e98b2375-f7a8-43da-8310-93747ded9224">

  - アラートの表示
  <img width="768" alt="スクリーンショット 2023-12-15 14 25 18" src="https://github.com/yumemi-inc/ios-training-fujii/assets/130953322/623f5c8f-c202-47d0-85cd-46c96b9b5488">

- showAlert()内でalertを定義し、`presentedViewController?.dismiss(animated: true)`で閉じる（現在の処理）
  - アラートを閉じる
  <img width="649" alt="スクリーンショット 2023-12-15 14 25 47" src="https://github.com/yumemi-inc/ios-training-fujii/assets/130953322/08c3fc1b-242b-4423-96a6-531b5982f7a7">

  - アラートの表示
 <img width="797" alt="スクリーンショット 2023-12-15 14 25 58" src="https://github.com/yumemi-inc/ios-training-fujii/assets/130953322/5a1c53a9-abbb-4a5e-9241-12027d293d19">

- その他の方法

どのような処理が一番適切か、ご指摘いただけると幸いです。


